### PR TITLE
fix: fixing pagination pages count

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.github.syr0ws</groupId>
     <artifactId>CraftVentory</artifactId>
-    <version>2.1.0</version>
+    <version>2.1.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/java/com/github/syr0ws/craftventory/internal/inventory/pagination/SimplePaginationModel.java
+++ b/src/main/java/com/github/syr0ws/craftventory/internal/inventory/pagination/SimplePaginationModel.java
@@ -69,7 +69,8 @@ public class SimplePaginationModel<T> implements PaginationModel<T> {
 
     @Override
     public int countPages() {
-        return (int) Math.ceil(this.countItems() / (double) this.perPage);
+        int pages = (int) Math.ceil(this.countItems() / (double) this.perPage);
+        return pages > 0 ? pages : 1;
     }
 
     @Override


### PR DESCRIPTION
Fixing a bug in which where there was no paginated item, the number of pages was 0 instead of 1 (empty page is considered as a valid page).