### PR TITLE
chore: removing 'ALL' click type

### DIFF
--- a/src/main/java/com/github/syr0ws/craftventory/api/inventory/action/ClickType.java
+++ b/src/main/java/com/github/syr0ws/craftventory/api/inventory/action/ClickType.java
@@ -7,7 +7,7 @@ import java.util.Arrays;
  */
 public enum ClickType {
 
-    LEFT, RIGHT, MIDDLE, ALL;
+    LEFT, RIGHT, MIDDLE;
 
     /**
      * Determines whether a given name matches any defined {@link ClickType}.

--- a/src/main/java/com/github/syr0ws/craftventory/common/config/yaml/YamlCommonActionLoader.java
+++ b/src/main/java/com/github/syr0ws/craftventory/common/config/yaml/YamlCommonActionLoader.java
@@ -5,6 +5,7 @@ import com.github.syr0ws.craftventory.api.config.exception.InventoryConfigExcept
 import com.github.syr0ws.craftventory.api.inventory.action.ClickType;
 import org.bukkit.configuration.ConfigurationSection;
 
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -15,12 +16,9 @@ public abstract class YamlCommonActionLoader implements ClickActionLoader<Config
 
     protected Set<ClickType> loadClickTypes(ConfigurationSection section) throws InventoryConfigException {
 
-        Set<ClickType> clickTypes = new HashSet<>();
-
         // If the property is not set, all clicks are handled by default.
         if (!section.isSet(CLICK_TYPES_KEY)) {
-            clickTypes.add(ClickType.ALL);
-            return clickTypes;
+            return Collections.emptySet();
         }
 
         // When the property is set, checking that it is a list.
@@ -29,6 +27,7 @@ public abstract class YamlCommonActionLoader implements ClickActionLoader<Config
         }
 
         List<String> clickTypeNames = section.getStringList(CLICK_TYPES_KEY);
+        Set<ClickType> clickTypes = new HashSet<>();
 
         for (String clickTypeName : clickTypeNames) {
 

--- a/src/main/java/com/github/syr0ws/craftventory/internal/config/yaml/YamlInventoryPaginationLoader.java
+++ b/src/main/java/com/github/syr0ws/craftventory/internal/config/yaml/YamlInventoryPaginationLoader.java
@@ -78,10 +78,10 @@ public class YamlInventoryPaginationLoader {
         SimpleInventoryItemConfig nextPageItem = nextPage.key();
 
         previousPageItem.setId(IdUtil.getPaginationPreviousPageItemId(paginationId));
-        previousPageItem.getActions().add(new PreviousPageAction(Collections.singleton(ClickType.ALL), paginationId));
+        previousPageItem.getActions().add(new PreviousPageAction(Collections.emptySet(), paginationId));
 
         nextPageItem.setId(IdUtil.getPaginationNextPageItemId(paginationId));
-        nextPageItem.getActions().add(new NextPageAction(Collections.singleton(ClickType.ALL), paginationId));
+        nextPageItem.getActions().add(new NextPageAction(Collections.emptySet(), paginationId));
 
         return new SimplePaginationConfig(
                 paginationId,

--- a/src/main/java/com/github/syr0ws/craftventory/internal/inventory/listener/CraftVentoryListener.java
+++ b/src/main/java/com/github/syr0ws/craftventory/internal/inventory/listener/CraftVentoryListener.java
@@ -235,7 +235,8 @@ public class CraftVentoryListener implements Listener {
 
         Set<ClickType> clickTypes = action.getClickTypes();
 
-        if (clickTypes.contains(ClickType.ALL)) {
+        // If no click type is specified for the action, we consider that all clicks are allowed.
+        if (clickTypes.isEmpty()) {
             return true;
         }
 


### PR DESCRIPTION
Removing the `ALL` click type and considering that an empty allowed click types collection in a `ClickAction` is equivalent to all clicks allowed.